### PR TITLE
add configuration to launching on win32 x86_64

### DIFF
--- a/features/org.xmind.cathy.platform.feature/feature.xml
+++ b/features/org.xmind.cathy.platform.feature/feature.xml
@@ -914,5 +914,26 @@ which is available at http://www.gnu.org/licenses/lgpl.html .
          install-size="0"
          version="0.0.0"
          unpack="false"/>
+      
+   <plugin
+         id="org.eclipse.swt.win32.win32.x86_64"
+         os="win32"
+         ws="win32"
+         arch="x86_64"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         fragment="true"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.equinox.launcher.win32.win32.x86_64"
+         os="win32"
+         ws="win32"
+         arch="x86_64"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         fragment="true"/> 
 
 </feature>


### PR DESCRIPTION
xmind have x86_64 for linux, but no for windows x86_64
just add these two config section, we can launch it in windows x86_64
can open very large xmind file more than 28MB and so on if you have huge memory.